### PR TITLE
Check if line channel is closed before sending to it

### DIFF
--- a/Hydrunfile
+++ b/Hydrunfile
@@ -31,7 +31,7 @@ if [ "$1" = "go" ]; then
     make depend
 
     # Build
-    CGO_ENABLED=0 bagop -j "$(nproc)" -b "$2" -x '(android/*|ios/*|plan9/*|aix/*)' -p "make build/$2 DST=\$DST" -d out
+    CGO_ENABLED=0 bagop -j "$(nproc)" -b "$2" -x '(android/*|ios/*|plan9/*|aix/*|linux/loong64)' -p "make build/$2 DST=\$DST" -d out
 
     exit 0
 fi


### PR DESCRIPTION
This fixes a race condition that occurred after closing an adapter.