### PR TITLE
feat: add basic auth support for remote address

### DIFF
--- a/pkg/wrtcconn/adapter.go
+++ b/pkg/wrtcconn/adapter.go
@@ -2,6 +2,7 @@ package wrtcconn
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"io"
 	"net/url"
@@ -191,7 +192,13 @@ func (a *Adapter) Open() (chan string, error) {
 				ctx, cancel := context.WithTimeout(a.ctx, a.config.Timeout)
 				defer cancel()
 
-				conn, _, err := websocket.DefaultDialer.DialContext(ctx, u.String(), nil)
+				headers := http.Header{}
+				if u.User != nil {
+					headers.Set("Authorization", "Basic " + base64.StdEncoding.EncodeToString([]byte(u.User.String())))
+					u.User = nil
+				}
+
+				conn, _, err := websocket.DefaultDialer.DialContext(ctx, u.String(), headers)
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
It's important for the signaling server to be routable over the open internet so distant peers can connect, but it doesn't necessarily needs to be public. Right now it is impossible to setup a signaling server for private use without introducing additional hops.
With this change, it is possible to add minimal authentication through a reverse proxy to setup a private signaling server while still being openly routable.